### PR TITLE
Basic API and Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-backend/__pycache__
+__pycache__
 
 .DS_Store
 .env

--- a/backend/api.py
+++ b/backend/api.py
@@ -152,7 +152,7 @@ class Game(SimpleNamespace):
 
         print(" ")
         print(
-            f'{player.name} discards {card.symbol}',
+            f'{player.name} captures {target.symbol}',
             '\n'.join(state.render()),
             sep='\n', end='\n\n',
         )

--- a/backend/api.py
+++ b/backend/api.py
@@ -111,55 +111,100 @@ class Game(SimpleNamespace):
         return JSONResponse({"message": "discard accepted"}, status_code=200)
 
     async def build(request):
-        # takes a game, player, card and target
-        return JSONResponse({"message": "Not Implemented"}, status_code=501)
+        try:
+            body = loads(await request.json())
+            
+            # Make sure a gamge exists
+            current = body["game"]
+            if current not in GAMES:
+                return JSONResponse({"error": f"Unable to find game {current!r}"}, status_code=412)
+            state = GAMES[current] 
+
+            # XXX: Hack for now to retrieve the player by name. Maybe we should
+            # have better way to do this.
+            pl = [p for p in state.players if p.name == body["player"]]
+            if not pl:
+                return JSONResponse({"error": "Could not find {player!r}"}, status_code=412)
+            player = pl[0]
+            
+            try:
+                card = [*state.hands[player]][body["card"]]
+            except IndexError:
+                return JSONResponse({"error": f"Unable to find card {body['card']}"}, status_code=412)
+            except Exception as e:
+                return JSONResponse({"error": f"{e}"}, status_code=412)
+
+            try:
+                target = [*state.table][body["target"]]
+            except IndexError:
+                return JSONResponse({"error": f"Unable to find card {body['target']}"}, status_code=412)
+            except Exception as e:
+                return JSONResponse({"error": f"{e}"}, status_code=412)
+            
+            try:
+                state = state.with_build(player, card, target)
+            except ValueError:
+                return JSONResponse({"Rejected": f"Unable to build {player!r} {card!r} {target!r}"}, status_code=412)
+
+            print(" ")
+            print(
+                f'{player.name} builds {target}',
+                '\n'.join(state.render()),
+                sep='\n', end='\n\n',
+            )
+
+            GAMES[current] = state
+        except Exception as e:
+            return JSONResponse({"error": f"{e}"}, status_code=412)
+        
+        return JSONResponse({"message": "build accepted"}, status_code=200)
 
     async def capture(request):
-        # try:
-        body = loads(await request.json())
-        
-        # Make sure a gamge exists
-        current = body["game"]
-        if current not in GAMES:
-            return JSONResponse({"error": f"Unable to find game {current!r}"}, status_code=412)
-        state = GAMES[current] 
-
-        # XXX: Hack for now to retrieve the player by name. Maybe we should
-        # have better way to do this.
-        pl = [p for p in state.players if p.name == body["player"]]
-        if not pl:
-            return JSONResponse({"error": "Could not find {player!r}"}, status_code=412)
-        player = pl[0]
-        
         try:
-            card = [*state.hands[player]][body["card"]]
-        except IndexError:
-            return JSONResponse({"error": f"Unable to find card {body['card']}"}, status_code=412)
+            body = loads(await request.json())
+            
+            # Make sure a gamge exists
+            current = body["game"]
+            if current not in GAMES:
+                return JSONResponse({"error": f"Unable to find game {current!r}"}, status_code=412)
+            state = GAMES[current] 
+
+            # XXX: Hack for now to retrieve the player by name. Maybe we should
+            # have better way to do this.
+            pl = [p for p in state.players if p.name == body["player"]]
+            if not pl:
+                return JSONResponse({"error": "Could not find {player!r}"}, status_code=412)
+            player = pl[0]
+            
+            try:
+                card = [*state.hands[player]][body["card"]]
+            except IndexError:
+                return JSONResponse({"error": f"Unable to find card {body['card']}"}, status_code=412)
+            except Exception as e:
+                return JSONResponse({"error": f"{e}"}, status_code=412)
+
+            try:
+                target = [*state.table][body["target"]]
+            except IndexError:
+                return JSONResponse({"error": f"Unable to find card {body['target']}"}, status_code=412)
+            except Exception as e:
+                return JSONResponse({"error": f"{e}"}, status_code=412)
+            
+            try:
+                state = state.with_capture(player, card, target)
+            except ValueError:
+                return JSONResponse({"Rejected": f"Unable to capture {player!r} {card!r} {target!r}"}, status_code=412)
+
+            print(" ")
+            print(
+                f'{player.name} captures {target}',
+                '\n'.join(state.render()),
+                sep='\n', end='\n\n',
+            )
+
+            GAMES[current] = state
         except Exception as e:
             return JSONResponse({"error": f"{e}"}, status_code=412)
-
-        try:
-            target = [*state.table][body["target"]]
-        except IndexError:
-            return JSONResponse({"error": f"Unable to find card {body['target']}"}, status_code=412)
-        except Exception as e:
-            return JSONResponse({"error": f"{e}"}, status_code=412)
-        
-        try:
-            state = state.with_capture(player, card, target)
-        except ValueError:
-            return JSONResponse({"Rejected": f"Unable to capture {player!r} {card!r} {target!r}"}, status_code=412)
-
-        print(" ")
-        print(
-            f'{player.name} captures {target.symbol}',
-            '\n'.join(state.render()),
-            sep='\n', end='\n\n',
-        )
-
-        GAMES[current] = state
-        # except Exception as e:
-        #     return JSONResponse({"error": f"{e}"}, status_code=412)
         
         return JSONResponse({"message": "capture accepted"}, status_code=200)
 

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,64 +1,141 @@
+from json import loads
+from uuid import uuid4
 from types import SimpleNamespace
 from asyncio import sleep
 from itertools import count
 
 from starlette.routing import Mount, Route, WebSocketRoute
+from starlette.endpoints import HTTPEndpoint
 from starlette.responses import JSONResponse
 from starlette.websockets import WebSocket
 from starlette.applications import Starlette
 
+from engine import Player, game
+
+# Testing temporary storage
+GAMES = {}
+MAX_PLAYERS = 6
+
 
 class Test(SimpleNamespace):
     async def simple(request):
-        return JSONResponse({'success': True})
+        return JSONResponse({"success": True})
+
 
 class WsTest(SimpleNamespace):
     async def simple(socket):
         await socket.accept()
-        await socket.send_json({'success': True})
+        await socket.send_json({"success": True})
         await socket.close()
 
     async def counter(socket):
         await socket.accept()
         for x in count(1):
-            await socket.send_json({'count': x})
-            await sleep(.5)
+            await socket.send_json({"count": x})
+            await sleep(0.5)
         await socket.close()
 
-GAMES = {
-    'abc123': [],
-}
+
 class Game(SimpleNamespace):
     async def new_game(request):
-        pass
+
+        requested_players = None
+        try:
+            body = loads(await request.json())
+            requested_players = body["players"]
+            players = {Player.from_name(name) for name in requested_players}
+
+            if len(requested_players) == 0:
+                return JSONResponse(
+                    {"error": "Must supply players names"}, status_code=412
+                )
+            elif len(requested_players) >= MAX_PLAYERS:
+                return JSONResponse(
+                    {"error": "Too many players, must be six or less"}, status_code=412
+                )
+        except Exception as e:
+            # Just for testing
+            return JSONResponse({"error": f"{e}"}, status_code=412)
+
+        id = uuid4().hex
+        GAMES[id] = game(players)
+
+        return JSONResponse({"game": id}, status_code=200)
+
     async def discard(request):
-        pass
+        try:
+            body = loads(await request.json())
+
+            # XXX: Need to validate all of these
+            current = body["game"]
+            player = body["player"]
+            card = int(body["card"])
+
+            print(f"{current!r} {player!r} {card!r}")
+            
+            state = GAMES[current] 
+            
+            # HACK: for now to find the player
+            pl = [p for p in state.players if p.name == player]
+            if not pl:
+                return JSONResponse({"error": "Could not fine {player!r}"}, status_code=412)
+            selected_player = pl[0]
+            
+            # XXX: Should use logging
+            print(f"{selected_player}")
+            print(f"{state.hands[selected_player]}")
+            print(f"{card}")
+
+            c = [*state.hands[selected_player]][card]
+            state = state.with_discard(selected_player, c)
+
+            print(" ")
+            print(
+                f'{selected_player.name} discards {c.symbol}',
+                '\n'.join(state.render()),
+                sep='\n', end='\n\n',
+            )
+
+            GAMES[current] = state
+        except Exception as e:
+            return JSONResponse({"error": f"{e}"}, status_code=412)
+
+        return JSONResponse({"message": "discard accepted"}, status_code=200)
+
     async def build(request):
-        pass
+        # takes a game, player, card and target
+        return JSONResponse({"message": "Not Implemented"}, status_code=501)
+
     async def capture(request):
-        pass
+        # takes a game, player, card and target
+        return JSONResponse({"message": "Not Implemented"}, status_code=501)
+
     async def state(request):
-        pass
+        # takes a game, player, card and target
+        return JSONResponse({"message": "Not Implemented"}, status_code=501)
+
     async def ws_state(socket):
-        pass
+        return JSONResponse({"message": "Not Implemented"}, status_code=501)
+
 
 v1_routes = [
-    Route('/new/{game}/{player}',          Game.new_game),
-    Route('/discard/{game}/{player}',      Game.discard),
-    Route('/build/{game}/{player}',        Game.build),
-    Route('/capture/{game}/{player}',      Game.capture),
-    Route('/state/{game}/{player}',        Game.state),
-    WebSocketRoute('/ws_state/{game}/{player}', Game.ws_state)
+    Route("/create/", Game.new_game, methods=["POST"]),
+    Route("/discard/", Game.discard, methods=["POST"]),
+    Route("/build/", Game.build, methods=["POST"]),
+    Route("/capture/", Game.capture, methods=["POST"]),
+    Route("/state/", Game.state),
+    Route("/test/simple/", Test.simple),
+    WebSocketRoute("/ws_state/", Game.ws_state),
 ]
 
 routes = [
-    Mount('/v1', routes=v1_routes),
-    Mount('/test', routes=[
-        Route('/simple', Test.simple),
-    ]),
-    Mount('/wstest', routes=[
-        WebSocketRoute('/simple', WsTest.simple),
-        WebSocketRoute('/counter', WsTest.counter),
-    ]),
+    Mount("/v1", routes=v1_routes),
+    Mount(
+        "/wstest",
+        routes=[
+            WebSocketRoute("/simple", WsTest.simple),
+            WebSocketRoute("/counter", WsTest.counter),
+        ],
+    ),
 ]
 app = Starlette(routes=routes, debug=True)

--- a/backend/engine.py
+++ b/backend/engine.py
@@ -156,7 +156,7 @@ class State:
         table.add(reduce(or_, {*targets, Unit.from_card(card)}))
         hand.add(deck.pop())
 
-        return replace(self, deck=deck, table=frozenset(table), hands={**self.hands, pl: frozenset(hand)})
+        return replace(self, deck=deck, table=frozenset(table), hands={**self.hands, player: frozenset(hand)})
 
     def with_capture(self, player, card, *targets):
         deck = [*self.deck]
@@ -170,7 +170,7 @@ class State:
         table.difference_update(targets)
         hand.add(deck.pop())
 
-        return replace(self, deck=deck, table=frozenset(table), hands={**self.hands, pl: frozenset(hand)})
+        return replace(self, deck=deck, table=frozenset(table), hands={**self.hands, player: frozenset(hand)})
 
     def render(self):
         return (

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,10 +1,17 @@
 anyio==3.6.2
+certifi==2022.12.7
 click==8.1.3
 h11==0.14.0
+h2==4.1.0
+hpack==4.0.0
+httpcore==0.16.3
 httptools==0.5.0
+httpx==0.23.1
+hyperframe==6.0.1
 idna==3.4
 python-dotenv==0.21.0
 PyYAML==6.0
+rfc3986==1.5.0
 sniffio==1.3.0
 starlette==0.23.1
 uvicorn==0.20.0

--- a/client/casino.py
+++ b/client/casino.py
@@ -27,12 +27,11 @@ def make_params(args):
 
     if args.game:
         params['game'] = args.game
-
-    if args.target:
+    
+    # Hmmm... Wthat the...
+    if args.target or args.target == 0:
         params['target'] = args.target
-    if args.card:
-        params['card'] = args.card
-    if args.card:
+    if args.card or args.card == 0:
         params['card'] = args.card
 
     return params

--- a/client/casino.py
+++ b/client/casino.py
@@ -1,0 +1,100 @@
+import asyncio
+
+from json import dumps 
+from logging import DEBUG, basicConfig, getLogger
+from argparse import ArgumentParser
+
+from httpx import HTTPError
+
+from client_api import Casino, ENDPOINTS
+
+logger = getLogger(__name__)
+basicConfig(
+    level=DEBUG,
+    format="%(asctime)s %(levelname)s %(name)-10s %(message)s",
+    datefmt="%d-%b %H:%M:%S",
+)
+
+def make_params(args):
+    # XXX: Just for quick testing
+
+    params = {}
+    # Such close naming what could go wrong?
+    if args.players:
+        params['players'] = args.players
+    if args.player:
+        params['player'] = args.player
+
+    if args.game:
+        params['game'] = args.game
+
+    if args.target:
+        params['target'] = args.target
+    if args.card:
+        params['card'] = args.card
+    if args.card:
+        params['card'] = args.card
+
+    return params
+
+async def process(args):
+    async with Casino.connect() as api:
+        params = make_params(args)
+        fn = getattr(api, ENDPOINTS[args.action])
+        logger.debug(f"Action: {ENDPOINTS[args.action]}")
+        logger.debug(f"Params: {params}")
+        try:
+            if params:
+                results = await fn(params=dumps(params))
+            else:
+                results = await fn()
+        except HTTPError as e:
+            msg = f"HTTP Error @ {e.request.url}"
+            logger.error(msg)
+            results = {"status code": 404, "messge": f"{msg}"}
+        except Exception as e:
+            msg = f"Unknown Exception @ {e}"
+            logger.error(msg)
+            results = {"status code": 404, "messge": f"{msg}"}
+
+    logger.info(results)
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Casino")
+    parser.add_argument(
+        "action",
+        choices=ENDPOINTS,
+        help="The action you would like to take in the game",
+    )
+    parser.add_argument(
+        "-target",
+        default=None,
+        type=int,
+        help="# of the Card Target the action is preformed with",
+    )
+    parser.add_argument(
+        "-game",
+        default=None,
+        help="Game the action is preformed with",
+    )
+    parser.add_argument(
+        "-card",
+        default=None,
+        type=int,
+        help="# of the Card the action is preformed with",
+    )
+    parser.add_argument(
+        "-player",
+        default=None,
+        help="Player the action is preformed with",
+    )
+    parser.add_argument(
+        "-players",
+        default=None,
+        nargs="+",
+        help="Players to start the game with",
+    )
+
+    args = parser.parse_args()
+    asyncio.run(process(args))

--- a/client/client_api.py
+++ b/client/client_api.py
@@ -1,0 +1,91 @@
+from inspect import signature
+from logging import DEBUG, basicConfig, getLogger
+from contextlib import asynccontextmanager
+from collections import namedtuple
+from dataclasses import dataclass
+
+from httpx import AsyncClient, Timeout
+
+logger = getLogger(__name__)
+basicConfig(
+    level=DEBUG,
+    format="%(asctime)s %(levelname)s %(name)-10s %(message)s",
+    datefmt="%d-%b %H:%M:%S",
+)
+
+TIMEOUTS = Timeout(5.0, read=5.0, write=5.0, connect=5.0, pool=5.0)
+CASINO = "http://127.0.0.1:8000/v1/"
+
+
+class Endpoints:
+    REGISTRY = {}
+
+    @classmethod
+    def register(cls, ep):
+        def dec(f):
+            cls.REGISTRY[ep] = f.__name__
+            return f
+
+        return dec
+
+
+@dataclass
+class Casino:
+
+    client: AsyncClient
+    API: str
+
+    async def get(self, endpoint):
+        return (await self.client.get(f"{self.API}{endpoint}")).json()
+
+    async def post(self, endpoint, params):
+        try:
+            return (await self.client.post(f"{self.API}{endpoint}", json=params)).json()
+        except Exception as e:
+            print(e)
+
+    @Endpoints.register("discard")
+    async def discard(self, *, params: dict):
+        """"""
+        return await self.post("discard/", params)
+
+    @Endpoints.register("build")
+    async def build(self, *, params: dict):
+        """"""
+        return await self.post("build/", params)
+
+    @Endpoints.register("capture")
+    async def capture(self, *, params: dict):
+        """"""
+        return await self.post("capture/", params)
+
+    @Endpoints.register("create")
+    async def create(self, *, params: dict):
+        """Create a new game"""
+        return await self.post("create/", params)
+
+    @Endpoints.register("state")
+    async def state(self):
+        """"""
+        return await self.get("state/")
+
+    @Endpoints.register("test")
+    async def test(self):
+        """POL"""
+        return await self.get("test/simple/")
+
+    @classmethod
+    @asynccontextmanager
+    async def connect(cls, *, API=CASINO):
+
+        headers = {
+            "User-Agent": "Barriere d'Enghien-les-Bains",
+            "Content-Type": "application/json",
+        }
+        async with AsyncClient(
+            headers=headers, http2=True, follow_redirects=True
+        ) as client:
+            yield cls(client, API=API)
+
+
+ENDPOINTS = Endpoints.REGISTRY

--- a/dev.yml
+++ b/dev.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       dockerfile: docker/frontend.dockerfile
+    environment:
+      PYTHONHASHSEED: 0
     volumes:
         - ./frontend:/app
 


### PR DESCRIPTION
A **dead simple** starting implementation for the API and a client so we can test endpoints & engine logic.

This feels like a _D-_ in terms of fast iteration cycles but maybe its a step in the right direction? If we wanted to really play from the command line I think a "_shell-like_" client could be neat. 

Maybe this client could be useful for integrating some of the testing that Michel is working on?

Once we have the endpoints roughed in Emmet and I discussed breaking up different tasks 

- [ ] Do the endpoints work as expected-ish?
To start a game bring the containers up via `./up.sh` and from another terminal or Tmux pane navigate to the `client/` folder:

```
python casino.py create -players name1 name2 name3
```
You should receive a game id `{'game': 'c0bfc5d0c4684d5aa57a78e92e988ef4'}` __the game id will be different for you__

From there you should be able to interact with the game via:

```
python casino.py discard -player jef -card 1 -game c0bfc5d0c4684d5aa57a78e92e988ef4
or
python casino.py build  -player mzam -card 2 -target 2 -game c0bfc5d0c4684d5aa57a78e92e988ef4 
or
python casino.py capture  -player mzam -card 3 -target 2 -game c0bfc5d0c4684d5aa57a78e92e988ef4
```
also the test endpoint should work via `python casino.py test` 

<img width="1691" alt="Screenshot 2022-12-21 at 5 30 27 PM" src="https://user-images.githubusercontent.com/7703829/209014891-2ad9011b-ef5a-49b3-8566-0748683da029.png">

```
usage: casino.py [-h] [-target TARGET] [-game GAME] [-card CARD] [-player PLAYER]
                 [-players PLAYERS [PLAYERS ...]]
                 {discard,build,capture,create,state,test}

Casino

positional arguments:
  {discard,build,capture,create,state,test}
                        The action you would like to take in the game

options:
  -h, --help            show this help message and exit
  -target TARGET        # of the Card Target the action is preformed with
  -game GAME            Game the action is preformed with
  -card CARD            # of the Card the action is preformed with
  -player PLAYER        Player the action is preformed with
  -players PLAYERS [PLAYERS ...]
                        Players to start the game with
```   
