### PR TITLE
🎄 Game order synchronization

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -77,34 +77,28 @@ class Game(SimpleNamespace):
             if current not in GAMES:
                 return JSONResponse({"error": f"Unable to find game {current!r}"}, status_code=412)
             state = GAMES[current] 
-
-            # XXX: Hack for now to retrieve the player by name. Maybe we should
-            # have better way to do this.
-            pl = [p for p in state.players if p.name == body["player"]]
-            if not pl:
-                return JSONResponse({"error": "Could not fine {player!r}"}, status_code=412)
-            player = pl[0]
             
-            try:
-                card = [*state.hands[player]][body["card"]]
-            except IndexError:
-                return JSONResponse({"error": f"Unable to find card {body['card']}"}, status_code=412)
-            except Exception as e:
-                return JSONResponse({"error": f"{e}"}, status_code=412)
+            with state.players_turn(body["player"]) as player:
+                try:
+                    card = [*state.hands[player]][body["card"]]
+                except IndexError:
+                    return JSONResponse({"error": f"Unable to find card {body['card']}"}, status_code=412)
+                except Exception as e:
+                    return JSONResponse({"error": f"{e}"}, status_code=412)
 
-            try:
-                state = state.with_discard(player, card)
-            except ValueError:
-                return JSONResponse({"Rejected": f"Unable to discard {player!r} {card!r}"}, status_code=412)
+                try:
+                    state = state.with_discard(player, card)
+                except ValueError:
+                    return JSONResponse({"Rejected": f"Unable to discard {player!r} {card!r}"}, status_code=412)
 
-            print(" ")
-            print(
-                f'{player.name} discards {card.symbol}',
-                '\n'.join(state.render()),
-                sep='\n', end='\n\n',
-            )
+                print(" ")
+                print(
+                    f'{player.name} discards {card.symbol}',
+                    '\n'.join(state.render()),
+                    sep='\n', end='\n\n',
+                )
 
-            GAMES[current] = state
+                GAMES[current] = state
         except Exception as e:
             return JSONResponse({"error": f"{e}"}, status_code=412)
         
@@ -120,40 +114,34 @@ class Game(SimpleNamespace):
                 return JSONResponse({"error": f"Unable to find game {current!r}"}, status_code=412)
             state = GAMES[current] 
 
-            # XXX: Hack for now to retrieve the player by name. Maybe we should
-            # have better way to do this.
-            pl = [p for p in state.players if p.name == body["player"]]
-            if not pl:
-                return JSONResponse({"error": "Could not find {player!r}"}, status_code=412)
-            player = pl[0]
-            
-            try:
-                card = [*state.hands[player]][body["card"]]
-            except IndexError:
-                return JSONResponse({"error": f"Unable to find card {body['card']}"}, status_code=412)
-            except Exception as e:
-                return JSONResponse({"error": f"{e}"}, status_code=412)
+            with state.players_turn(body["player"]) as player:
+                try:
+                    card = [*state.hands[player]][body["card"]]
+                except IndexError:
+                    return JSONResponse({"error": f"Unable to find card {body['card']}"}, status_code=412)
+                except Exception as e:
+                    return JSONResponse({"error": f"{e}"}, status_code=412)
 
-            try:
-                target = [*state.table][body["target"]]
-            except IndexError:
-                return JSONResponse({"error": f"Unable to find card {body['target']}"}, status_code=412)
-            except Exception as e:
-                return JSONResponse({"error": f"{e}"}, status_code=412)
-            
-            try:
-                state = state.with_build(player, card, target)
-            except ValueError:
-                return JSONResponse({"Rejected": f"Unable to build {player!r} {card!r} {target!r}"}, status_code=412)
+                try:
+                    target = [*state.table][body["target"]]
+                except IndexError:
+                    return JSONResponse({"error": f"Unable to find card {body['target']}"}, status_code=412)
+                except Exception as e:
+                    return JSONResponse({"error": f"{e}"}, status_code=412)
+                
+                try:
+                    state = state.with_build(player, card, target)
+                except ValueError:
+                    return JSONResponse({"Rejected": f"Unable to build {player!r} {card!r} {target!r}"}, status_code=412)
 
-            print(" ")
-            print(
-                f'{player.name} builds {target}',
-                '\n'.join(state.render()),
-                sep='\n', end='\n\n',
-            )
+                print(" ")
+                print(
+                    f'{player.name} builds {target}',
+                    '\n'.join(state.render()),
+                    sep='\n', end='\n\n',
+                )
 
-            GAMES[current] = state
+                GAMES[current] = state
         except Exception as e:
             return JSONResponse({"error": f"{e}"}, status_code=412)
         
@@ -169,40 +157,34 @@ class Game(SimpleNamespace):
                 return JSONResponse({"error": f"Unable to find game {current!r}"}, status_code=412)
             state = GAMES[current] 
 
-            # XXX: Hack for now to retrieve the player by name. Maybe we should
-            # have better way to do this.
-            pl = [p for p in state.players if p.name == body["player"]]
-            if not pl:
-                return JSONResponse({"error": "Could not find {player!r}"}, status_code=412)
-            player = pl[0]
-            
-            try:
-                card = [*state.hands[player]][body["card"]]
-            except IndexError:
-                return JSONResponse({"error": f"Unable to find card {body['card']}"}, status_code=412)
-            except Exception as e:
-                return JSONResponse({"error": f"{e}"}, status_code=412)
+            with state.players_turn(body["player"]) as player:
+                try:
+                    card = [*state.hands[player]][body["card"]]
+                except IndexError:
+                    return JSONResponse({"error": f"Unable to find card {body['card']}"}, status_code=412)
+                except Exception as e:
+                    return JSONResponse({"error": f"{e}"}, status_code=412)
 
-            try:
-                target = [*state.table][body["target"]]
-            except IndexError:
-                return JSONResponse({"error": f"Unable to find card {body['target']}"}, status_code=412)
-            except Exception as e:
-                return JSONResponse({"error": f"{e}"}, status_code=412)
-            
-            try:
-                state = state.with_capture(player, card, target)
-            except ValueError:
-                return JSONResponse({"Rejected": f"Unable to capture {player!r} {card!r} {target!r}"}, status_code=412)
+                try:
+                    target = [*state.table][body["target"]]
+                except IndexError:
+                    return JSONResponse({"error": f"Unable to find card {body['target']}"}, status_code=412)
+                except Exception as e:
+                    return JSONResponse({"error": f"{e}"}, status_code=412)
+                
+                try:
+                    state = state.with_capture(player, card, target)
+                except ValueError:
+                    return JSONResponse({"Rejected": f"Unable to capture {player!r} {card!r} {target!r}"}, status_code=412)
 
-            print(" ")
-            print(
-                f'{player.name} captures {target}',
-                '\n'.join(state.render()),
-                sep='\n', end='\n\n',
-            )
+                print(" ")
+                print(
+                    f'{player.name} captures {target}',
+                    '\n'.join(state.render()),
+                    sep='\n', end='\n\n',
+                )
 
-            GAMES[current] = state
+                GAMES[current] = state
         except Exception as e:
             return JSONResponse({"error": f"{e}"}, status_code=412)
         

--- a/backend/engine.py
+++ b/backend/engine.py
@@ -1,59 +1,73 @@
 #!/usr/bin/env python3
-
-from collections import deque
-from random import Random
 from enum import Enum
-from itertools import product
-from functools import cached_property, reduce
-from dataclasses import dataclass, replace
-from collections import namedtuple
-from operator import or_
+from random import Random
 from typing import Union
-from sys import exit; import sys; sys.breakpointhook = exit; del sys, exit
+from operator import or_
+from functools import cached_property, reduce
+from itertools import product
+from contextlib import contextmanager
+from collections import deque, namedtuple
+from dataclasses import dataclass, replace
 
-Suit = Enum('Suit', '''
+
+class NotTurnException(Exception):
+    ...
+
+
+class MissingPlayerException(Exception):
+    ...
+
+
+Suit = Enum(
+    "Suit",
+    """
     Diamond Club
     Heart Spade
-''')
-Rank = Enum('Rank', '''
+""",
+)
+Rank = Enum(
+    "Rank",
+    """
     Two Three Four Five Six
     Seven Eight Nine Ten
     Jack Queen King Ace
-''')
+""",
+)
 
-class Card(namedtuple('Card', 'rank suit')):
+
+class Card(namedtuple("Card", "rank suit")):
     SUITS = {
-        Suit.Diamond:  '\N{black diamond suit}',
-        Suit.Club:     '\N{black club suit}',
-        Suit.Heart:    '\N{black heart suit}',
-        Suit.Spade:    '\N{black spade suit}',
+        Suit.Diamond: "\N{black diamond suit}",
+        Suit.Club: "\N{black club suit}",
+        Suit.Heart: "\N{black heart suit}",
+        Suit.Spade: "\N{black spade suit}",
     }
     RANKS = {
-        Rank.Two:    ' 2 ',
-        Rank.Three:  ' 3 ',
-        Rank.Four:   ' 4 ',
-        Rank.Five:   ' 5 ',
-        Rank.Six:    ' 6 ',
-        Rank.Seven:  ' 7 ',
-        Rank.Eight:  ' 8 ',
-        Rank.Nine:   ' 9 ',
-        Rank.Ten:    ' 10',
-        Rank.Jack:   ' J ',
-        Rank.Queen:  ' Q ',
-        Rank.King:   ' K ',
-        Rank.Ace:    ' A ',
+        Rank.Two: " 2 ",
+        Rank.Three: " 3 ",
+        Rank.Four: " 4 ",
+        Rank.Five: " 5 ",
+        Rank.Six: " 6 ",
+        Rank.Seven: " 7 ",
+        Rank.Eight: " 8 ",
+        Rank.Nine: " 9 ",
+        Rank.Ten: " 10",
+        Rank.Jack: " J ",
+        Rank.Queen: " Q ",
+        Rank.King: " K ",
+        Rank.Ace: " A ",
     }
     VALUES = {
-        Rank.Ace:    1,
-        Rank.Two:    2,
-        Rank.Three:  3,
-        Rank.Four:   4,
-        Rank.Five:   5,
-        Rank.Six:    6,
-        Rank.Seven:  7,
-        Rank.Eight:  8,
-        Rank.Nine:   9,
-        Rank.Ten:    10,
+        Rank.Ace: 1,
+        Rank.Two: 2,
+        Rank.Three: 3,
+        Rank.Four: 4,
+        Rank.Five: 5,
+        Rank.Six: 6,
+        Rank.Seven: 7,
+        Rank.Eight: 8,
+        Rank.Nine: 9,
+        Rank.Ten: 10,
     }
 
     @cached_property
@@ -63,8 +77,11 @@ class Card(namedtuple('Card', 'rank suit')):
     @cached_property
     def symbol(self):
         if self.suit in {Suit.Heart, Suit.Diamond}:
-            return f'\033[1;41m{self.RANKS[self.rank]}{self.SUITS[self.suit]}\033[1;37;0m'
-        return f'\033[1;7m{self.RANKS[self.rank]}{self.SUITS[self.suit]}\033[1;37;0m'
+            return (
+                f"\033[1;41m{self.RANKS[self.rank]}{self.SUITS[self.suit]} \033[1;37;0m"
+            )
+        return f"\033[1;7m{self.RANKS[self.rank]}{self.SUITS[self.suit]} \033[1;37;0m"
+
 
 STANDARD_DECK = [Card(r, s) for r, s in product(Rank, Suit)]
 
@@ -72,10 +89,12 @@ STANDARD_DECK = [Card(r, s) for r, s in product(Rank, Suit)]
 # combine: build
 # pair: capture
 
+
 @dataclass(frozen=True)
 class Player:
-    name   : str
-    points : int = 0
+    name: str
+    points: int = 0
+
     @classmethod
     def from_name(cls, name):
         return cls(name=name)
@@ -83,10 +102,11 @@ class Player:
     def __hash__(self):
         return hash(self.name)
 
+
 @dataclass(frozen=True)
 class Unit:
-    cards : frozenset[Card]
-    value : Union[int, None] = None
+    cards: frozenset[Card]
+    value: Union[int, None] = None
 
     @classmethod
     def from_card(cls, card):
@@ -94,26 +114,50 @@ class Unit:
 
     def render(self):
         if len(self.cards):
-            return '【{}】'.format(' '.join(c.symbol.lstrip() for c in self.cards))
-        return ' '.join(c.symbol for c in self.cards)
+            return "【{}】".format(" ".join(c.symbol.lstrip() for c in self.cards))
+        return " ".join(c.symbol for c in self.cards)
 
     def __or__(self, other):
         if self.value is None or other.value is None:
-            raise ValueError('cannot combine')
+            raise ValueError("cannot combine")
         if (self.value + other.value) > max(Card.VALUES.values()):
-            raise ValueError('cannot combine')
-        return Unit(cards=frozenset({*self.cards, *other.cards}), value=self.value+other.value)
+            raise ValueError("cannot combine")
+        return Unit(
+            cards=frozenset({*self.cards, *other.cards}), value=self.value + other.value
+        )
 
     def __hash__(self):
         return hash(self.cards)
 
+
 @dataclass(frozen=True)
 class State:
-    deck    : deque[Card]
-    table   : frozenset[Unit]
-    players : frozenset[Player]
-    hands   : dict[Player, frozenset[Card]]
-    capture : dict[Player, frozenset[Card]]
+    deck: deque[Card]
+    table: frozenset[Unit]
+    players: frozenset[Player]
+    hands: dict[Player, frozenset[Card]]
+    capture: dict[Player, frozenset[Card]]
+    player_order: deque[Player]
+
+    @contextmanager
+    def players_turn(self, player_name):
+        _player = None
+        for p in self.players:
+            if p.name == player_name:
+                _player = p
+                break
+
+        if not _player:
+            raise MissingPlayerException(f"Could not find player {player_name!r}")
+
+        if _player is not self.player_order[0]:
+            raise NotTurnException(f"Not {player_name!r}'s turn")
+
+        player = self.player_order.popleft()
+        try:
+            yield player
+        finally:
+            self.player_order.append(player)
 
     @classmethod
     def from_players(cls, deck, *players):
@@ -123,6 +167,7 @@ class State:
             players=frozenset(players),
             hands={pl: frozenset() for pl in players},
             capture={pl: frozenset() for pl in players},
+            player_order=deque(players),
         )
 
     def with_deal(self):
@@ -133,7 +178,12 @@ class State:
             for h in hands.values():
                 h.update(deck.pop() for _ in range(2))
             table.update(Unit.from_card(deck.pop()) for _ in range(2))
-        return replace(self, deck=deck, table=frozenset(table), hands={k: frozenset(v) for k, v in hands.items()})
+        return replace(
+            self,
+            deck=deck,
+            table=frozenset(table),
+            hands={k: frozenset(v) for k, v in hands.items()},
+        )
 
     def with_discard(self, player, card):
         deck = [*self.deck]
@@ -144,7 +194,12 @@ class State:
         table.add(Unit.from_card(card))
         hand.add(deck.pop())
 
-        return replace(self, deck=deck, table=frozenset(table), hands={**self.hands, player: frozenset(hand)})
+        return replace(
+            self,
+            deck=deck,
+            table=frozenset(table),
+            hands={**self.hands, player: frozenset(hand)},
+        )
 
     def with_build(self, player, card, *targets):
         deck = [*self.deck]
@@ -156,7 +211,12 @@ class State:
         table.add(reduce(or_, {*targets, Unit.from_card(card)}))
         hand.add(deck.pop())
 
-        return replace(self, deck=deck, table=frozenset(table), hands={**self.hands, player: frozenset(hand)})
+        return replace(
+            self,
+            deck=deck,
+            table=frozenset(table),
+            hands={**self.hands, player: frozenset(hand)},
+        )
 
     def with_capture(self, player, card, *targets):
         deck = [*self.deck]
@@ -164,77 +224,46 @@ class State:
         hand = {*self.hands[player]}
 
         if not all(card.value == t.value for t in targets):
-            raise ValueError(f'cannot capture {targets} with {card}')
+            raise ValueError(f"cannot capture {targets} with {card}")
 
         hand.remove(card)
         table.difference_update(targets)
         hand.add(deck.pop())
 
-        return replace(self, deck=deck, table=frozenset(table), hands={**self.hands, player: frozenset(hand)})
+        return replace(
+            self,
+            deck=deck,
+            table=frozenset(table),
+            hands={**self.hands, player: frozenset(hand)},
+        )
 
     def render(self):
         return (
+            "",
+            f"Current Turn: {self.player_order[0].name}",
             f"Table: {' '.join(u.render() for u in self.table)}\n",
             *(
-                f"{p.name:<8} {'  '.join(c.symbol for c in h)}" 
+                f"{p.name:<8} {'  '.join(c.symbol for c in h)}"
                 for p, h in sorted(self.hands.items(), key=lambda pl_h: pl_h[0].name)
-            )
+            ),
         )
 
-def game(players):
-    rnd = Random(0)
 
-    deck = [c for c in STANDARD_DECK]
-    rnd.shuffle(deck)
-
+def game(players, seed=0, _deck=None):
+    rnd = Random(seed)
+    if _deck:
+        deck = _deck
+    else:
+        deck = [c for c in STANDARD_DECK]
+        rnd.shuffle(deck)
     state = State.from_players(deck, *players)
     state = state.with_deal()
-    
+
     return state
 
-if __name__ == '__main__':
-    
-    players = {
-        Player.from_name(name)
-        for name in 'Cameron Emmet Jef Michel'.split()
-    }
 
-    state = game(players)
-    print(
-        '\n'.join(state.render()),
-        sep='\n', end='\n\n',
-    )
+if __name__ == "__main__":
 
-
-    pl = [*players][0]
-    c = [*state.hands[pl]][0]
-    state = state.with_discard(pl, c)
-
-    print(" ")
-    print(
-        f'{pl.name} discards {c.symbol}',
-        '\n'.join(state.render()),
-        sep='\n', end='\n\n',
-    )
-
-    pl = [*players][1]
-    c = [*state.hands[pl]][-1]
-    t = [*state.table][-2]
-    state = state.with_build(pl, c, t)
-
-    print(
-        f'{pl.name} builds {c.symbol} on top of {t.render()}',
-        '\n'.join(state.render()),
-        sep='\n', end='\n\n',
-    )
-
-    pl = [*players][2]
-    c = [*state.hands[pl]][3]
-    t = [*state.table][-1]
-    state = state.with_capture(pl, c, t)
-
-    print(
-        f'{pl.name} captures {t.render()} using {c.symbol}',
-        '\n'.join(state.render()),
-        sep='\n', end='\n\n',
-    )
+    DECK = [c for c in STANDARD_DECK]
+    deck = [d for d in DECK if d.rank.value in [2, 3, 5]]
+    print(f" ".join([c.symbol for c in deck]))

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 anyio==3.6.2
+attrs==22.2.0
 certifi==2022.12.7
 click==8.1.3
 h11==0.14.0
@@ -9,6 +10,10 @@ httptools==0.5.0
 httpx==0.23.1
 hyperframe==6.0.1
 idna==3.4
+iniconfig==1.1.1
+packaging==22.0
+pluggy==1.0.0
+pytest==7.2.0
 python-dotenv==0.21.0
 PyYAML==6.0
 rfc3986==1.5.0

--- a/backend/tests/test_engine.py
+++ b/backend/tests/test_engine.py
@@ -1,0 +1,131 @@
+from pytest import raises
+
+from engine import game, MissingPlayerException, Player, STANDARD_DECK, Suit, Rank
+
+# Smoke tests (that basically test that pytest is working). But maybe a
+# starting porint?
+
+# python hashseed set to 0 via export PYTHONHASHSEED=0
+
+DECK = [c for c in STANDARD_DECK]
+
+
+def test_suits():
+
+    suits = ["Diamond", "Club", "Heart", "Spade"]
+
+    for s in suits:
+        assert Suit[s]
+
+    assert len([*Suit]) == len(suits)
+
+
+def test_players_from_name():
+
+    player_to_create = "Hyacinth"
+    player = Player.from_name(player_to_create)
+
+    assert player.name == player_to_create
+    assert player.points == 0
+
+
+def test_state_from_game():
+
+    player_to_create = "Hyacinth"
+    player = Player.from_name(player_to_create)
+
+    state = game([player])
+
+    assert player in state.players
+    assert len(state.deck) == 44  # Aftr deal
+
+
+def test_with_player():
+
+    hyacinth = Player.from_name("Hyacinth")
+    state = game([hyacinth])
+
+    with state.players_turn("Hyacinth") as player:
+        assert player is hyacinth
+
+    with raises(MissingPlayerException):
+        with state.players_turn("Not Hyacinth") as player:
+            ...
+
+
+def test_disguard():
+    state = game([Player.from_name("Hyacinth"), Player.from_name("Boonsri")])
+    # Inital state for debugging game
+    print(
+        "\n".join(state.render()),
+        sep="\n",
+        end="\n",
+    )
+
+    with state.players_turn("Hyacinth") as player:
+        card = [*state.hands[player]][0]  # K<clubs>
+        state = state.with_discard(player, card)
+        assert card not in [*state.hands[player]]
+
+    # Discarded state for debugging game
+    print(" ")
+    print(
+        f"{player.name} discards {card.symbol}",
+        "\n".join(state.render()),
+        sep="\n",
+        end="\n\n",
+    )
+
+
+def test_with_build():
+    deck = [d for d in DECK if d.rank in [Rank.Two, Rank.Three, Rank.Five]]
+    state = game([Player.from_name("Hyacinth")], _deck=deck)
+    # Inital state for debugging game
+    print(
+        "\n".join(state.render()),
+        sep="\n",
+        end="\n",
+    )
+
+    with state.players_turn("Hyacinth") as player:
+        card = [*state.hands[player]][0]  # 5<spade>
+        target = [*state.table][0]  # 3<club>
+        state = state.with_build(player, card, target)
+        assert card not in [*state.hands[player]]
+        
+        assert card in {c for c in [*state.table][0].cards}
+        assert [*target.cards][0] in {c for c in [*state.table][0].cards}
+
+    print(" ")
+    print(
+        f"{player.name} builds on {' '.join([c.symbol for c in target.cards])} with {card.symbol}",
+        "\n".join(state.render()),
+        sep="\n",
+        end="\n\n",
+    )
+
+def test_with_capture():
+    deck = [d for d in DECK if d.rank in [Rank.Two, Rank.Three, Rank.Five]]
+    state = game([Player.from_name("Hyacinth")], _deck=deck)
+    # Inital state for debugging game
+    print(
+        "\n".join(state.render()),
+        sep="\n",
+        end="\n",
+    )
+
+    with state.players_turn("Hyacinth") as player:
+        card = [*state.hands[player]][0]  # 5<spade>
+        target = [*state.table][1]  # 5<diamond>
+        state = state.with_capture(player, card, target)
+        assert card not in [*state.hands[player]]
+        assert [*target.cards][0] not in {c for u in [*state.table] for c in u.cards}
+        assert len([*state.table]) == 3
+
+    print(" ")
+    print(
+        f"{player.name} captures {' '.join([c.symbol for c in target.cards])} with {card.symbol}",
+        "\n".join(state.render()),
+        sep="\n",
+        end="\n\n",
+    )

--- a/client/casino.py
+++ b/client/casino.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-player",
         default=None,
-        help="Player the action is preformed with",
+        help="Name of the Player whos trying to preform the action",
     )
     parser.add_argument(
         "-players",


### PR DESCRIPTION
Introduced `player_order` to the `State` class and a context manager `players_turn` to manage turn synchronization.

```python
with state.players_turn("Name_of_player") as player:
    state = state.with_discard(player, card)
```

The `players_turn` verifies that the player exists and it is indeed the players turn, and moves to the next player after the move has been completed. This is nice API wise because it just rejects requests by anyone except the current Player.

- [ ] Does this seems like a good idea?
- [ ] Should we let people re-try their turn if they make an incorrect move?

I also added some _smoke tests_ to help with basic sanity. Not sure if they're great tests but I figured it was a starting point & maybe @michelzam could integrate his tests, too.

`python -m pytest` to run the tests (`python -m pytest -s` to see game output) in `/backend/tests/`

I also used Black to format so diffs are kinda a bummer to look at. My bad!